### PR TITLE
Add CSB configuration

### DIFF
--- a/csb.js
+++ b/csb.js
@@ -3,4 +3,10 @@ module.exports = {
         '@endouble.com/eslint-config-endouble/react',
         'plugin:cypress/recommended',
     ],
+    overrides: [
+        {
+            files: ['**/*test.js'],
+            env: { jest: true },
+        },
+    ],
 };

--- a/csb.js
+++ b/csb.js
@@ -1,0 +1,6 @@
+module.exports = {
+    extends: [
+        '@endouble.com/eslint-config-endouble/react',
+        'plugin:cypress/recommended',
+    ],
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endouble.com/eslint-config-endouble",
-  "version": "2.1.3",
+  "version": "2.2.0",
   "description": "Endouble's Javascript ESLint configuration",
   "main": "./index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "babel-eslint": "^10.0.0",
     "eslint": "^5.7.0",
     "eslint-config-airbnb": "^17.1.0",
+    "eslint-plugin-cypress": "^2.8.1",
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-jsx-a11y": "^6.1.2",
     "eslint-plugin-react": "^7.11.1",

--- a/react.js
+++ b/react.js
@@ -1,5 +1,8 @@
 module.exports = {
-    extends: ['airbnb', '@endouble.com/eslint-config-endouble'],
+    extends: [
+        'airbnb',
+        '@endouble.com/eslint-config-endouble',
+    ],
     rules: {
         'react/jsx-indent': ['error', 4],
         'react/jsx-indent-props': ['error', 4],

--- a/test/test.js
+++ b/test/test.js
@@ -1,5 +1,6 @@
 const defaults = require('../.');
 const react = require('../react');
+const csb = require('../csb');
 
 describe('test basic properties of all configurations', () => {
     it('should match the snapshot', () => {
@@ -22,10 +23,20 @@ describe('test basic properties of all configurations', () => {
     });
 
     it('should extend "airbnb" and defaults', () => {
-        expect(react.extends).toEqual(['airbnb', '@endouble.com/eslint-config-endouble']);
+        expect(react.extends).toEqual([
+            'airbnb',
+            '@endouble.com/eslint-config-endouble',
+        ]);
     });
 
     it('should have "react" as a plugin', () => {
         expect(react.plugins).toContain('react');
+    });
+
+    it('should extend "react" and "cypress"', () => {
+        expect(csb.extends).toEqual([
+            '@endouble.com/eslint-config-endouble/react',
+            'plugin:cypress/recommended',
+        ]);
     });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1278,6 +1278,13 @@ eslint-module-utils@^2.3.0:
     debug "^2.6.8"
     pkg-dir "^2.0.0"
 
+eslint-plugin-cypress@^2.8.1:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-cypress/-/eslint-plugin-cypress-2.8.1.tgz#981a0f3658b40de430bcf05cabc96b396487c91f"
+  integrity sha512-jDpcP+MmjmqQO/x3bwIXgp4cl7Q66RYS5/IsuOQP4Qo2sEqE3DI8tTxBQ1EhnV5qEDd2Z2TYHR+5vYI6oCN4uw==
+  dependencies:
+    globals "^11.12.0"
+
 eslint-plugin-import@^2.14.0:
   version "2.16.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.16.0.tgz#97ac3e75d0791c4fac0e15ef388510217be7f66f"
@@ -1732,6 +1739,11 @@ globals@^11.1.0, globals@^11.7.0:
   version "11.8.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.8.0.tgz#c1ef45ee9bed6badf0663c5cb90e8d1adec1321d"
   integrity sha512-io6LkyPVuzCHBSQV9fmOwxZkUk6nIaGmxheLDgmuFv89j0fm2aqDbIXKAGfzCMHqz3HLF2Zf8WSG6VqMh2qFmA==
+
+globals@^11.12.0:
+  version "11.12.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
+  integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
 
 globby@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
This PR adds an specific configuration file for CSB websites, including:
- `cypress` plugin and its defaults
- `overrides` for test files

After this, a `.eslintrc` file on a CSB project that looks like this:
```json
{
    "extends": "@endouble.com/eslint-config-endouble/react",
    "globals": {
        "fetch": false,
        "FormData": true
    },
    "overrides": [{
        "files": ["**/*test.js"],
        "env": {
            "jest": true
        }
    }]
}
```

Will be:
```json
{
    "extends": "@endouble.com/eslint-config-endouble/csb"
}
```